### PR TITLE
Fix typo: min -> len

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ script:
  - flake8 --select BLK tests/test_cases/*.py
  - echo "Checking we report expected black changes"
  - diff tests/test_changes/hello_world.txt <(flake8 --select BLK tests/test_changes/hello_world.py)
+ - diff tests/test_changes/hello_world_EOF.txt <(flake8 --select BLK tests/test_changes/hello_world_EOF.py)
 
 notifications:
   email: false

--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,9 @@ Version Released   Changes
 ------- ---------- -----------------------------------------------------------
 v0.0.1  2019-01-10 - Initial public release.
 v0.0.2  2019-02-15 - Document syntax error behaviour (no BLK error reported).
+v0.0.3  2019-02-21 - Bug fix where ``W292 no newline at end of file`` applies,
+                     Contribution from
+                     `Sapphire Becker <https://github.com/sapphire-janrain>`_.
 ======= ========== ===========================================================
 
 

--- a/flake8_black.py
+++ b/flake8_black.py
@@ -9,7 +9,7 @@ import black
 from flake8 import utils as stdin_utils
 
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 
 black_prefix = "BLK"
 

--- a/flake8_black.py
+++ b/flake8_black.py
@@ -30,7 +30,7 @@ def find_diff_start(old_src, new_src):
         # Difference at the end of the line...
         return line, min(len(old), len(new))
     # Difference at the end of the file...
-    return min(len(old_lines), min(new_lines)), 0
+    return min(len(old_lines), len(new_lines)), 0
 
 
 class BlackStyleChecker(object):

--- a/tests/test_changes/hello_world_EOF.py
+++ b/tests/test_changes/hello_world_EOF.py
@@ -1,0 +1,11 @@
+"""Print 'Hello world' to the terminal.
+
+This is a simple test script which in the formal form has a missing final
+line break - which black will add.
+
+The point of this is the edit position will be at the very end of the file,
+which is a corner case.
+"""
+
+
+print("Hello world")

--- a/tests/test_changes/hello_world_EOF.txt
+++ b/tests/test_changes/hello_world_EOF.txt
@@ -1,0 +1,1 @@
+tests/test_changes/hello_world_EOF.py:12:1: BLK100 Black would make changes.


### PR DESCRIPTION
Was having this error occasionally while running flake8 over my code:

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/multiprocessing/pool.py", line 119, in worker
    result = (True, func(*args, **kwds))
  File "~/.local/lib/python3.6/site-packages/flake8/checker.py", line 669, in _run_checks
    return checker.run_checks()
  File "~/.local/lib/python3.6/site-packages/flake8/checker.py", line 608, in run_checks
    self.run_ast_checks()
  File "~/.local/lib/python3.6/site-packages/flake8/checker.py", line 504, in run_ast_checks
    for (line_number, offset, text, check) in runner:
  File "~/.local/lib/python3.6/site-packages/flake8_black.py", line 108, in run
    line, col = find_diff_start(source, new_code)
  File "~/.local/lib/python3.6/site-packages/flake8_black.py", line 33, in find_diff_start
    return min(len(old_lines), min(new_lines)), 0
TypeError: '<' not supported between instances of 'str' and 'int'
```

Just a quick fix for it.