### PR TITLE
v0.1.0 with pyproject.toml support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,9 @@ script:
  - flake8 --select BLK *.py
  - echo "Checking we report no errors on these test cases"
  - flake8 --select BLK tests/test_cases/*.py
+ - flake8 --select BLK --max-line-length 90 tests/test_cases/*.py
  - flake8 --select BLK tests/with_pyproject_toml/*.py
+ - flake8 --select BLK --max-line-length 88 tests/with_pyproject_toml/
  - flake8 --select BLK tests/non_conflicting_configurations/*.py
  - echo "Checking we report expected black changes"
  - diff tests/test_changes/hello_world.txt <(flake8 --select BLK tests/test_changes/hello_world.py)

--- a/README.rst
+++ b/README.rst
@@ -83,8 +83,13 @@ You can request only the ``BLK`` codes be shown using::
 Configuration
 -------------
 
+We assume you are familiar with `flake8 configuration
+<http://flake8.pycqa.org/en/latest/user/configuration.html>`_ and
+`black configuration
+<https://black.readthedocs.io/en/stable/pyproject_toml.html>`_.
+
 We recommend using the following settings in your ``flake8`` configuration,
-for example in your ``.flake8``  file::
+for example in your ``.flake8``, ``setup.cfg``, or ``tox.ini`` file::
 
     [flake8]
     # Recommend matching the black default line length of 88,
@@ -94,17 +99,29 @@ for example in your ``.flake8``  file::
         # See https://github.com/PyCQA/pycodestyle/issues/373
         E203,
 
-In order not to trigger flake8's ``E501 line too long`` errors, the plugin
-passes the ``flake8`` maximum line length when it calls ``black``,
-equivalent to doing ``black -l 88 --check *.py`` at the command line.
-
 Note currently ``pycodestyle`` gives false positives on the spaces ``black``
 uses for slices, which ``flake8`` reports as ``E203: whitespace before ':'``.
 Until `pyflakes issue 373 <https://github.com/PyCQA/pycodestyle/issues/373>`_
 is fixed, and ``flake8`` is updated, we suggest disabling this style check.
 
-If you are using custom value of maximum line length parameter, check that black configuration (pyproject.toml) and
-flake8 configuration (.flake8) use the same value. Otherwise, you will get BLK997 error.
+It is unusual to modify the ``black`` configuration, and so by default in
+order not to trigger flake8's ``E501 line too long`` errors, the plugin
+passes the ``flake8`` maximum line length when it calls ``black``,
+equivalent to doing ``black -l XX --check *.py`` at the command line.
+
+However, if a ``pyproject.toml`` file is found, the plugin will look at the
+following ``black`` settings:
+
+* ``target_version``
+* ``skip_string_normalization``
+* ``line_length``
+
+Ensure this ``line_length`` and the ``flake8`` max-line-length settings are
+equal, otherwise ``BLK800`` will be reported for every Python file examined.
+
+The plugin does *NOT* consider the ``black`` settings for ``include`` and
+``exclude``, which would duplicate functionality built into ``flake8``.
+
 
 Ignoring validation codes
 -------------------------

--- a/README.rst
+++ b/README.rst
@@ -139,6 +139,9 @@ Version History
 ======= ============ ===========================================================
 Version Release date   Changes
 ------- ------------ -----------------------------------------------------------
+v0.1.0  *pending*    - Looks in ``black`` settings file ``pyproject.toml`` for
+                       some settings. New code ``BLK800`` for length conflict.
+                       Contribution from `Alex <https://github.com/ADKosm>`_.
 v0.0.4  2019-03-15   - Supports black 19.3b0 which changed a function call.
 v0.0.3  2019-02-21   - Bug fix when ``W292 no newline at end of file`` applies,
                        contribution from

--- a/flake8_black.py
+++ b/flake8_black.py
@@ -11,7 +11,7 @@ import toml
 from flake8 import utils as stdin_utils
 
 
-__version__ = "0.0.4"
+__version__ = "0.1.0"
 
 black_prefix = "BLK"
 

--- a/flake8_black.py
+++ b/flake8_black.py
@@ -91,11 +91,11 @@ class BlackStyleChecker(object):
     def _file_mode(self):
         try:
             target_versions = set()
-            black_line_length = 88  # default black line-length value
             skip_string_normalization = False
 
             black_config = self._load_black_config()
             if black_config:
+                black_line_length = 88  # default black line-length value
                 target_versions = {
                     black.TargetVersion[val.upper()]
                     for val in black_config.get("target_version", [])
@@ -104,12 +104,11 @@ class BlackStyleChecker(object):
                 skip_string_normalization = black_config.get(
                     "skip_string_normalization", False
                 )
-
-            if self.line_length != black_line_length:
-                raise ConfigConflictLineLen(
-                    "Conflicting line length in flake8 and black settings "
-                    "(%i vs %i)." % (self.line_length, black_line_length)
-                )
+                if self.line_length != black_line_length:
+                    raise ConfigConflictLineLen(
+                        "Conflicting line length in flake8 and black settings "
+                        "(%i vs %i)." % (self.line_length, black_line_length)
+                    )
 
             return black.FileMode(
                 target_versions=target_versions,


### PR DESCRIPTION
Do these follow on changes from #4 make sense @ADKosm?

Mostly cosmetic - documentation and rewording and renaming the new code to ``BLK800``.

There is a functional change, stopping the length conflict being triggered if there was no ``pyproject.toml`` file present, and the user had something other than 88 as the max line length via ``flake8``.

What do you think should happen if the flake8 configuration gives a line length (e.g. 120, something different to the black default) and while there is a ``pyproject.toml`` file present it does not specify the length? Right now this assumes the presence of any black configuration file means 88, and so gives the error.

I aim to release this early next week (doing a release late on a Friday is a bad plan).