### PR TITLE
 Ignore flake8 max-line-length, only use black config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,15 @@ script:
  - flake8 --select BLK *.py
  - echo "Checking we report no errors on these test cases"
  - flake8 --select BLK tests/test_cases/*.py
+ - flake8 --select BLK --max-line-length 50 tests/test_cases/*.py
+ - flake8 --select BLK --max-line-length 90 tests/test_cases/*.py
  - flake8 --select BLK tests/with_pyproject_toml/*.py
+ - flake8 --select BLK --max-line-length 88 tests/with_pyproject_toml/
  - flake8 --select BLK tests/non_conflicting_configurations/*.py
+ - flake8 --select BLK tests/conflicting_configurations/*.py
  - echo "Checking we report expected black changes"
  - diff tests/test_changes/hello_world.txt <(flake8 --select BLK tests/test_changes/hello_world.py)
  - diff tests/test_changes/hello_world_EOF.txt <(flake8 --select BLK tests/test_changes/hello_world_EOF.py)
- - diff tests/conflicting_configurations/output.txt <(flake8 --select BLK tests/conflicting_configurations/*.py | sort)
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,17 +29,8 @@ script:
  - echo "On this machine \$LANG=$LANG"
  - echo "Checking our own code passes"
  - flake8 --select BLK *.py
- - echo "Checking we report no errors on these test cases"
- - flake8 --select BLK tests/test_cases/*.py
- - flake8 --select BLK --max-line-length 50 tests/test_cases/*.py
- - flake8 --select BLK --max-line-length 90 tests/test_cases/*.py
- - flake8 --select BLK tests/with_pyproject_toml/*.py
- - flake8 --select BLK --max-line-length 88 tests/with_pyproject_toml/
- - flake8 --select BLK tests/non_conflicting_configurations/*.py
- - flake8 --select BLK tests/conflicting_configurations/*.py
- - echo "Checking we report expected black changes"
- - diff tests/test_changes/hello_world.txt <(flake8 --select BLK tests/test_changes/hello_world.py)
- - diff tests/test_changes/hello_world_EOF.txt <(flake8 --select BLK tests/test_changes/hello_world_EOF.py)
+ - cd tests
+ - ./run_tests.sh
 
 notifications:
   email: false

--- a/README.rst
+++ b/README.rst
@@ -41,15 +41,13 @@ v3.0, flake8 has supported longer prefixes, therefore this plugin uses ``BLK``
 as its prefix.
 
 ====== =======================================================================
-Code   Description
+Code   Description (*and notes*)
 ------ -----------------------------------------------------------------------
 BLK100 Black would make changes.
-BLK8## Configuration error (various):
-BLK800 Conflicting line length in flake8 and black settings.
-BLK9## Internal error (various):
+BLK9## Internal error (*various, listed below*):
 BLK900 Failed to load file: ...
 BLK901 Invalid input.
-BLK998 Could not access flake8 line length setting.
+BLK998 Could not access flake8 line length setting (*no longer used*).
 BLK999 Unexpected exception.
 ====== =======================================================================
 
@@ -84,28 +82,37 @@ You can request only the ``BLK`` codes be shown using::
 Configuration
 -------------
 
+We assume you are familiar with `flake8 configuration
+<http://flake8.pycqa.org/en/latest/user/configuration.html>`_ and
+`black configuration
+<https://black.readthedocs.io/en/stable/pyproject_toml.html>`_.
+
 We recommend using the following settings in your ``flake8`` configuration,
-for example in your ``.flake8``  file::
+for example in your ``.flake8``, ``setup.cfg``, or ``tox.ini`` file::
 
     [flake8]
-    # Recommend matching the black default line length of 88,
-    # rather than the flake8 default of 79:
+    # Recommend matching the black line length (default 88),
+    # rather than using the flake8 default of 79:
     max-line-length = 88
     extend-ignore =
         # See https://github.com/PyCQA/pycodestyle/issues/373
         E203,
-
-In order not to trigger flake8's ``E501 line too long`` errors, the plugin
-passes the ``flake8`` maximum line length when it calls ``black``,
-equivalent to doing ``black -l 88 --check *.py`` at the command line.
 
 Note currently ``pycodestyle`` gives false positives on the spaces ``black``
 uses for slices, which ``flake8`` reports as ``E203: whitespace before ':'``.
 Until `pyflakes issue 373 <https://github.com/PyCQA/pycodestyle/issues/373>`_
 is fixed, and ``flake8`` is updated, we suggest disabling this style check.
 
-If you are using custom value of maximum line length parameter, check that black configuration (pyproject.toml) and
-flake8 configuration (.flake8) use the same value. Otherwise, you will get BLK997 error.
+If a ``pyproject.toml`` file is found, the plugin will look at the following
+``black`` settings:
+
+* ``target_version``
+* ``skip_string_normalization``
+* ``line_length``
+
+The plugin does *NOT* consider the ``black`` settings for ``include`` and
+``exclude``, which would duplicate functionality built into ``flake8``.
+
 
 Ignoring validation codes
 -------------------------
@@ -123,6 +130,12 @@ Version History
 ======= ============ ===========================================================
 Version Release date   Changes
 ------- ------------ -----------------------------------------------------------
+v0.1.0  *pending*    - Looks in ``black`` settings file ``pyproject.toml`` for
+                       * ``target_version``
+                       * ``skip_string_normalization``
+                       * ``line_length``
+                       Contribution from `Alex <https://github.com/ADKosm>`_.
+                     - WARNING: Now ignores ``flake8`` max-line-length setting.
 v0.0.4  2019-03-15   - Supports black 19.3b0 which changed a function call.
 v0.0.3  2019-02-21   - Bug fix when ``W292 no newline at end of file`` applies,
                        contribution from

--- a/flake8_black.py
+++ b/flake8_black.py
@@ -48,7 +48,9 @@ class BlackStyleChecker(object):
         self.tree = tree
         self.filename = filename
         # Following for legacy versions of black only:
+        self.file_mode = 0  # was: black.FileMode.AUTO_DETECT
         self.line_length = 88
+        # See property self._file_mode for new black versions
 
     def _load_black_config(self):
         source_path = (
@@ -83,6 +85,8 @@ class BlackStyleChecker(object):
             )
         # Save line length for legacy mode
         self.line_length = black_line_length
+        if skip_string_normalization:
+            self.file_mode |= 4  # was black.FileMode.NO_STRING_NORMALIZATION
         try:
             # Recent versions of black have a FileMode object
             # which includes the line length setting
@@ -122,7 +126,10 @@ class BlackStyleChecker(object):
                 if self._file_mode is None:
                     # Legacy version of black, 18.9b0 or older
                     new_code = black.format_file_contents(
-                        source, line_length=self.line_length, fast=False
+                        source,
+                        line_length=self.line_length,
+                        fast=False,
+                        mode=black.FileMode(self.file_mode),
                     )
                 else:
                     # For black 19.3b0 or later

--- a/flake8_black.py
+++ b/flake8_black.py
@@ -47,10 +47,10 @@ class BlackStyleChecker(object):
         """Initialise."""
         self.tree = tree
         self.filename = filename
-        # Following for legacy versions of black only:
-        self.file_mode = 0  # was: black.FileMode.AUTO_DETECT
         self.line_length = 88
-        # See property self._file_mode for new black versions
+        # Following for legacy versions of black only,
+        # see property self._file_mode for new black versions:
+        self.file_mode = 0  # was: black.FileMode.AUTO_DETECT
 
     def _load_black_config(self):
         source_path = (
@@ -69,7 +69,6 @@ class BlackStyleChecker(object):
 
     @property
     def _file_mode(self):
-        black_line_length = 88  # default black line-length value
         target_versions = set()
         skip_string_normalization = False
 
@@ -79,13 +78,12 @@ class BlackStyleChecker(object):
                 black.TargetVersion[val.upper()]
                 for val in black_config.get("target_version", [])
             }
-            black_line_length = black_config.get("line_length", black_line_length)
+            self.line_length = black_config.get("line_length", self.line_length)
             skip_string_normalization = black_config.get(
                 "skip_string_normalization", False
             )
-        # Save line length for legacy mode
-        self.line_length = black_line_length
         if skip_string_normalization:
+            # Used with older versions of black:
             self.file_mode |= 4  # was black.FileMode.NO_STRING_NORMALIZATION
         try:
             # Recent versions of black have a FileMode object

--- a/tests/conflicting_configurations/output.txt
+++ b/tests/conflicting_configurations/output.txt
@@ -1,2 +1,0 @@
-tests/conflicting_configurations/goodbye.py:0:1: BLK800 Conflicting line length in flake8 and black settings (120 vs 90).
-tests/conflicting_configurations/hello.py:0:1: BLK800 Conflicting line length in flake8 and black settings (120 vs 90).

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+# Assumes in the tests/ directory
+
+echo "Checking we report no errors on these test cases"
+flake8 --select BLK test_cases/*.py
+flake8 --select BLK --max-line-length 50 test_cases/*.py
+flake8 --select BLK --max-line-length 90 test_cases/*.py
+flake8 --select BLK with_pyproject_toml/*.py
+flake8 --select BLK --max-line-length 88 with_pyproject_toml/
+flake8 --select BLK non_conflicting_configurations/*.py
+flake8 --select BLK conflicting_configurations/*.py
+
+echo "Checking we report expected black changes"
+diff test_changes/hello_world.txt <(flake8 --select BLK test_changes/hello_world.py)
+diff test_changes/hello_world_EOF.txt <(flake8 --select BLK test_changes/hello_world_EOF.py)
+
+echo "Tests passed."

--- a/tests/test_changes/hello_world.txt
+++ b/tests/test_changes/hello_world.txt
@@ -1,1 +1,1 @@
-tests/test_changes/hello_world.py:12:6: BLK100 Black would make changes.
+test_changes/hello_world.py:12:6: BLK100 Black would make changes.

--- a/tests/test_changes/hello_world_EOF.txt
+++ b/tests/test_changes/hello_world_EOF.txt
@@ -1,1 +1,1 @@
-tests/test_changes/hello_world_EOF.py:12:1: BLK100 Black would make changes.
+test_changes/hello_world_EOF.py:12:1: BLK100 Black would make changes.


### PR DESCRIPTION
This would close #6, and bump the version to v0.1.0

Comments welcomed @ADKosm 