### PR TITLE
feature/GLOBAL_CONFIG: Added global black configuration option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
  - "if grep '\t' *.py *.rst; then echo 'Tabs are bad, please use four spaces.'; false; fi"
  - "if grep -n -r '[[:blank:]]$' *.py *.rst; then echo 'Please remove trailing whitespace.'; false; fi"
  - pip install --upgrade pip setuptools
- - pip install flake8 flake8-docstrings restructuredtext-lint black
+ - pip install flake8 restructuredtext-lint black
  - echo "Using restructuredtext-lint to check documentation"
  - restructuredtext-lint *.rst
  - echo "Using flake8 to check Python code"
@@ -29,6 +29,7 @@ script:
  - echo "On this machine \$LANG=$LANG"
  - echo "Checking our own code passes"
  - flake8 --select BLK *.py
+ - pip install -r requirements-test.txt
  - cd tests
  - ./run_tests.sh
 

--- a/flake8_black.py
+++ b/flake8_black.py
@@ -15,6 +15,10 @@ __version__ = "0.1.0"
 
 black_prefix = "BLK"
 
+pyproject = "pyproject.toml"
+
+global_config_path = ".config/flake8-black"
+
 
 def find_diff_start(old_src, new_src):
     """Find line number and column number where text first differs."""
@@ -59,13 +63,21 @@ class BlackStyleChecker(object):
             else Path.cwd().as_posix()
         )
         project_root = black.find_project_root((Path(source_path),))
-        path = project_root / "pyproject.toml"
+        path = project_root / pyproject
 
+        config = self._load_from_path(path)
+
+        if not config:
+            other_path = Path.home() / global_config_path / pyproject
+            config = self._load_from_path(other_path)
+
+        return config
+
+    def _load_from_path(self, path):
         if path.is_file():
             pyproject_toml = toml.load(str(path))
             config = pyproject_toml.get("tool", {}).get("black", {})
             return {k.replace("--", "").replace("-", "_"): v for k, v in config.items()}
-        return None
 
     @property
     def _file_mode(self):

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,5 @@
+# Additional requirements are only needed to run the test suite
+pytest>=5.0.0
+pyfakefs>=3.6
+-e .
+-r requirements.txt

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install testing requirements:
+#     pip install -r requirements-test.txt
+
 # Assumes in the tests/ directory
 
 echo "Checking we report no errors on these test cases"
@@ -16,5 +19,7 @@ flake8 --select BLK conflicting_configurations/*.py
 echo "Checking we report expected black changes"
 diff test_changes/hello_world.txt <(flake8 --select BLK test_changes/hello_world.py)
 diff test_changes/hello_world_EOF.txt <(flake8 --select BLK test_changes/hello_world_EOF.py)
+
+pytest -q
 
 echo "Tests passed."

--- a/tests/test_global_config.py
+++ b/tests/test_global_config.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+import flake8_black
+
+
+def test_global_config(fs):
+    home = Path.home() / ".config/flake8-black/pyproject.toml"
+    fs.create_file(home, contents="[tool.black]\nskip-string-normalization = true\n")
+
+    bl = flake8_black.BlackStyleChecker("foo", "tests/test_changes/hello_world.py")
+    assert bl._load_black_config() == {'skip_string_normalization': True}


### PR DESCRIPTION
If no `pyproject.toml` file is found, flake8-black will fallback on
the global configuration for `black` found in
`$HOME/.config/flake8-black/pyproject.toml`. Syntax stays the same.