### PR TITLE
feature/BLACK_CONFIG: Black configuration file configurable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,6 +144,9 @@ Version History
 ======= ============ ===========================================================
 Version Release date   Changes
 ------- ------------ -----------------------------------------------------------
+v0.1.1  2019-08-06   - Option to use a (global) black configuration file,
+                       contribution from
+                       `Tomasz Grining <https://github.com/098799>`_.
 v0.1.0  2019-06-03   - Uses main ``black`` settings from ``pyproject.toml``,
                        contribution from `Alex <https://github.com/ADKosm>`_.
                      - WARNING: Now ignores ``flake8`` max-line-length setting.

--- a/flake8_black.py
+++ b/flake8_black.py
@@ -13,7 +13,7 @@ import toml
 from flake8 import utils as stdin_utils
 
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 black_prefix = "BLK"
 

--- a/tests/flake8_config/flake8
+++ b/tests/flake8_config/flake8
@@ -1,0 +1,2 @@
+[flake8]
+black-config = ../with_pyproject_toml/pyproject.toml

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -9,6 +9,7 @@ flake8 --select BLK test_cases/*.py
 flake8 --select BLK --max-line-length 50 test_cases/*.py
 flake8 --select BLK --max-line-length 90 test_cases/*.py
 flake8 --select BLK with_pyproject_toml/*.py
+flake8 --select BLK without_pyproject_toml/*.py --config=flake8_config/flake8
 flake8 --select BLK --max-line-length 88 with_pyproject_toml/
 flake8 --select BLK non_conflicting_configurations/*.py
 flake8 --select BLK conflicting_configurations/*.py

--- a/tests/without_pyproject_toml/ordinary_quotes.py
+++ b/tests/without_pyproject_toml/ordinary_quotes.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Print 'Hello world' to the terminal.
+
+This is a simple test script using a hashbang line
+and a PEP263 encoding line.
+We use ordinary quotes in this test.
+"""
+
+print('Hello world')


### PR DESCRIPTION
Added `flake8-black-config` parameter to be set in flake8
configuration file, which points to the `.toml` file that should be
used instead of the default black `pyptoject.toml`.