### PR TITLE
Catch bad TOML files; allow using no TOML file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,3 +7,9 @@ extend-ignore =
     # See https://github.com/PyCQA/pycodestyle/issues/373
     # flake8/pycodechecker give false positives on black code
     E203,
+
+
+# =====================
+# flake-quote settings:
+# =====================
+inline-quotes = double

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,7 @@ BLK100 Black would make changes.
 BLK9## Internal error (*various, listed below*):
 BLK900 Failed to load file: ...
 BLK901 Invalid input.
+BLK997 Invalid TOML file: ...
 BLK998 Could not access flake8 line length setting (*no longer used*).
 BLK999 Unexpected exception.
 ====== =======================================================================
@@ -146,7 +147,8 @@ Version Release date   Changes
 ------- ------------ -----------------------------------------------------------
 v0.1.1  2019-08-06   - Option to use a (global) black configuration file,
                        contribution from
-                       `Tomasz Grining <https://github.com/098799>`_.
+		       `Tomasz Grining <https://github.com/098799>`_.
+                     - New ``BLK997`` if can't parse ``pyproject.toml`` file.
 v0.1.0  2019-06-03   - Uses main ``black`` settings from ``pyproject.toml``,
                        contribution from `Alex <https://github.com/ADKosm>`_.
                      - WARNING: Now ignores ``flake8`` max-line-length setting.

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -5,21 +5,42 @@ IFS=$'\n\t'
 # Assumes in the tests/ directory
 
 echo "Checking our configuration option appears in help"
-flake8 -h 2>&1  | grep "black-config"
+flake8 -h 2>&1 | grep "black-config"
+
+set +o pipefail
+
+echo "Checking we report an error when can't find specified config file"
+flake8 --black-config does_not_exist.toml 2>&1 | grep -i "could not find"
+
+echo "Checking failure with mal-formed TOML file"
+flake8 --select BLK test_cases/ --black-config with_bad_toml/pyproject.toml 2>&1 | grep -i "could not parse"
+
+set -o pipefail
 
 echo "Checking we report no errors on these test cases"
 flake8 --select BLK test_cases/*.py
+# Adding --black-config '' should have no effect:
+flake8 --select BLK test_cases/*.py --black-config ''
+# Adding --black-config '-' would ignore any pyproject.toml file:
+flake8 --select BLK test_cases/*.py --black-config '-'
 flake8 --select BLK --max-line-length 50 test_cases/*.py
 flake8 --select BLK --max-line-length 90 test_cases/*.py
 flake8 --select BLK with_pyproject_toml/*.py
 flake8 --select BLK with_pyproject_toml/*.py --black-config with_pyproject_toml/pyproject.toml
 flake8 --select BLK without_pyproject_toml/*.py --config=flake8_config/flake8
 flake8 --select BLK --max-line-length 88 with_pyproject_toml/
+flake8 --select BLK without_pyproject_toml/*.py --black-config with_pyproject_toml/pyproject.toml
+# Adding --black-config '' should have no effect:
+flake8 --select BLK --max-line-length 88 with_pyproject_toml/ --black-config ''
 flake8 --select BLK non_conflicting_configurations/*.py
 flake8 --select BLK conflicting_configurations/*.py
+# Here testing using --black-config '-' to ignore the broken pyproject.toml file:
+flake8 --select BLK with_bad_toml/hello_world.py --black-config '-'
 
 echo "Checking we report expected black changes"
 diff test_changes/hello_world.txt <(flake8 --select BLK test_changes/hello_world.py)
 diff test_changes/hello_world_EOF.txt <(flake8 --select BLK test_changes/hello_world_EOF.py)
+diff test_changes/hello_world_EOF.txt <(flake8 --select BLK test_changes/hello_world_EOF.py --black-config '')
+diff with_bad_toml/hello_world.txt <(flake8 --select BLK with_bad_toml/hello_world.py)
 
 echo "Tests passed."

--- a/tests/with_bad_toml/hello_world.py
+++ b/tests/with_bad_toml/hello_world.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Print 'Hello world' to the terminal.
+
+This is a simple test script using a hashbang line
+and a PEP263 encoding line.
+"""
+
+print("Hello world")

--- a/tests/with_bad_toml/hello_world.txt
+++ b/tests/with_bad_toml/hello_world.txt
@@ -1,0 +1,1 @@
+with_bad_toml/hello_world.py:0:1: BLK997 Invalid TOML file: with_bad_toml/pyproject.toml

--- a/tests/with_bad_toml/pyproject.toml
+++ b/tests/with_bad_toml/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+skip-string-normalization = true
+# This line is (a) in the wrong file, and (b) invalid syntax
+black-config=


### PR DESCRIPTION
Builds on #11, adds new ``BLK997`` if a ``pyproject.toml`` file is invalid, allows using ``flake8 --black-config '-' ...`` to mean ignore any ``pyproject.toml`` file.

Adds explicit failure during configuration parsing for specified TOML file missing (#12) or invalid, although currently an ugly traceback.