### PR TITLE
Rework TOML loading; BLK907 for invalid pyproject.toml

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -19,6 +19,8 @@ per-file-ignores =
     tests/test_fail/mixed_tab_spaces.py: E101,E999,W191
     tests/with_pyproject_toml/ordinary_quotes.py: Q000
     tests/test_cases/mixed_tab_spaces.py: E101,E999,W191
+    # The bad TOML file breaks black checking this file:
+    tests/with_bad_toml/hello_world.py: BLK997,
 
 # =====================
 # flake-quote settings:

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,7 @@ BLK100 Black would make changes.
 BLK9## Internal error (*various, listed below*):
 BLK900 Failed to load file: ...
 BLK901 Invalid input.
+BLK997 Invalid TOML file: ...
 BLK998 Could not access flake8 line length setting (*no longer used*).
 BLK999 Unexpected exception.
 ====== =======================================================================
@@ -147,6 +148,7 @@ Version Release date   Changes
 v0.1.1  *pending*    - Option to use a (global) black configuration file,
                        contribution from
                        `Tomasz Grining <https://github.com/098799>`_.
+                     - New ``BLK997`` if can't parse ``pyproject.toml`` file.
                      - Logs configuration files, use ``-v`` or ``--verbose``.
                      - Fixed flake8 "builtins" parameter warning.
 v0.1.0  2019-06-03   - Uses main ``black`` settings from ``pyproject.toml``,

--- a/flake8_black.py
+++ b/flake8_black.py
@@ -3,7 +3,7 @@
 This is a plugin for the tool flake8 tool for checking Python
 soucre code using the tool black.
 """
-from functools import lru_cache
+
 from os import path
 from pathlib import Path
 
@@ -46,71 +46,101 @@ class BlackStyleChecker(object):
 
     STDIN_NAMES = {"stdin", "-", "(none)", None}
 
+    # Black settings
+    line_length = black.DEFAULT_LINE_LENGTH  # Expect to be 88
+    target_versions = set()
+    skip_string_normalization = False
+
+    # Which TOML have we loaded, and why?
+    toml_filename = None
+    toml_override = False
+
     def __init__(self, tree, filename="(none)"):
         """Initialise."""
         self.tree = tree
         self.filename = filename
-        self.line_length = black.DEFAULT_LINE_LENGTH  # Expect to be 88
         # Following for legacy versions of black only,
         # see property self._file_mode for new black versions:
         self.file_mode = 0  # was: black.FileMode.AUTO_DETECT
 
-    @property
-    @lru_cache()
-    def config_file(self):
-        """File path to the black configuration file."""
-        if self.flake8_black_config:
-            flake8_black_path = Path(self.flake8_black_config)
-
-            if self.flake8_config:
-                flake8_config_path = path.dirname(path.abspath(self.flake8_config))
-                return Path(flake8_config_path) / flake8_black_path
-
-            return flake8_black_path
-
+    def _update_black_config(self):
+        """Find and load any local pyproject.toml with black config."""
         source_path = (
             self.filename
             if self.filename not in self.STDIN_NAMES
             else Path.cwd().as_posix()
         )
         project_root = black.find_project_root((Path(source_path),))
-        return project_root / "pyproject.toml"
+        path = project_root / "pyproject.toml"
 
-    def _load_black_config(self):
-        if self.config_file.is_file():
-            LOG.info("flake8-black: Loading black config from %s" % self.config_file)
-            pyproject_toml = toml.load(str(self.config_file))
-            config = pyproject_toml.get("tool", {}).get("black", {})
-            return {k.replace("--", "").replace("-", "_"): v for k, v in config.items()}
-        elif self.config_file:
-            LOG.info("flake8-black: Did not find %s" % self.config_file)
-        return None
+        if path.is_file():
+            # Use this pyproject.toml for this python file,
+            # (unless configured with global override config)
+            self.load_black_toml(path, override=False)
+
+    @classmethod
+    def load_black_toml(cls, toml_filename, override=False):
+        """Load specified black configuration from TOML file."""
+        if not toml_filename:
+            if override:
+                cls.toml_filename = None
+                cls.toml_override = True
+            return
+        if cls.toml_filename == toml_filename:
+            LOG.info(
+                "flake8-black: already loaded black settings from %s", cls.toml_filename
+            )
+            return
+        elif override:
+            cls.toml_override = True
+            # Continue below...
+        elif cls.toml_filename:
+            LOG.info(
+                "flake8-black: ignoring %s in favour of %s",
+                toml_filename,
+                cls.toml_filename,
+            )
+            return
+        elif cls.toml_override:
+            LOG.info(
+                "flake8-black: ignoring %s as explicitly using no black config",
+                toml_filename,
+            )
+            return
+
+        LOG.info("flake8-black: loading black settings from %s", toml_filename)
+        cls.toml_filename = toml_filename
+        pyproject_toml = toml.load(str(toml_filename))
+        config = pyproject_toml.get("tool", {}).get("black", {})
+        black_config = {
+            k.replace("--", "").replace("-", "_"): v for k, v in config.items()
+        }
+
+        cls.target_versions = {
+            black.TargetVersion[val.upper()]
+            for val in black_config.get("target_version", [])
+        }
+        cls.line_length = black_config.get("line_length", cls.line_length)
+        cls.skip_string_normalization = black_config.get(
+            "skip_string_normalization", False
+        )
 
     @property
     def _file_mode(self):
-        target_versions = set()
-        skip_string_normalization = False
+        """Generate black.FileMode object (or set legacy alternative)."""
+        # Check for a local pyproject.toml
+        self._update_black_config()
 
-        black_config = self._load_black_config()
-        if black_config:
-            target_versions = {
-                black.TargetVersion[val.upper()]
-                for val in black_config.get("target_version", [])
-            }
-            self.line_length = black_config.get("line_length", self.line_length)
-            skip_string_normalization = black_config.get(
-                "skip_string_normalization", False
-            )
-        if skip_string_normalization:
+        if self.skip_string_normalization:
             # Used with older versions of black:
             self.file_mode |= 4  # was black.FileMode.NO_STRING_NORMALIZATION
         try:
             # Recent versions of black have a FileMode object
             # which includes the line length setting
             return black.FileMode(
-                target_versions=target_versions,
+                target_versions=self.target_versions,
                 line_length=self.line_length,
-                string_normalization=not skip_string_normalization,
+                string_normalization=not self.skip_string_normalization,
             )
         except TypeError as e:
             # Legacy mode for old versions of black
@@ -122,19 +152,52 @@ class BlackStyleChecker(object):
         """Adding black-config option."""
         parser.add_option(
             "--black-config",
+            metavar="TOML_FILENAME",
             default=None,
             action="store",
-            type="string",
+            # type="string",  <- breaks using None as a sentinal
             parse_from_config=True,
-            help="Path to black configuration file "
-            "(overrides the default pyproject.toml)",
+            help="Path to black TOML configuration file (overrides the "
+            "default 'pyproject.toml' detection; use empty string '' to mean "
+            "ignore all 'pyproject.toml' files).",
         )
 
     @classmethod
     def parse_options(cls, options):
         """Adding black-config option."""
-        cls.flake8_black_config = options.black_config
-        cls.flake8_config = options.config
+        # We have one and only one flake8 plugin configuration
+        if options.black_config is None:
+            LOG.info("flake8-black: No black configuration set")
+            return
+        if not options.black_config:
+            LOG.info("flake8-black: Explicitly using no black configuration file")
+            cls.load_black_toml(None, override=True)
+            return
+
+        # Validate the path setting - handling relative paths
+        black_config_path = Path(options.black_config)
+        if options.config:
+            # Assume black config path was via flake8 config file
+            base_path = Path(path.dirname(path.abspath(options.config)))
+            black_config_path = base_path / black_config_path
+        if not black_config_path.is_file():
+            # Want flake8 to abort, see:
+            # https://gitlab.com/pycqa/flake8/issues/559
+            raise ValueError(
+                "Plugin flake8-black could not find specified black config file: "
+                "--black-config %s" % black_config_path
+            )
+
+        # Now load the TOML file, and the black section within it
+        # This configuration is to override any local pyproject.toml
+        try:
+            cls.load_black_toml(black_config_path, override=True)
+        except toml.decoder.TomlDecodeError:
+            # Could raise BLK997, but view this as an abort condition
+            raise ValueError(
+                "Plugin flake8-black could not parse specified black config file: "
+                "--black-config %s" % black_config_path
+            )
 
     def run(self):
         """Use black to check code style."""
@@ -176,8 +239,10 @@ class BlackStyleChecker(object):
                 return
             except black.InvalidInput:
                 msg = "901 Invalid input."
-            except Exception as e:
-                msg = "999 Unexpected exception: %s" % e
+            except toml.decoder.TomlDecodeError:
+                msg = "997 Invalid TOML file: %s" % path.relpath(self.toml_filename)
+            except Exception as err:
+                msg = "999 Unexpected exception: %s" % err
             else:
                 assert (
                     new_code != source

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -5,21 +5,41 @@ IFS=$'\n\t'
 # Assumes in the tests/ directory
 
 echo "Checking our configuration option appears in help"
-flake8 -h 2>&1  | grep "black-config"
+flake8 -h 2>&1 | grep "black-config"
+
+set +o pipefail
+
+echo "Checking we report an error when can't find specified config file"
+flake8 --black-config does_not_exist.toml 2>&1 | grep -i "could not find"
+
+echo "Checking failure with mal-formed TOML file"
+flake8 --select BLK test_cases/ --black-config with_bad_toml/pyproject.toml 2>&1 | grep -i "could not parse"
+
+set -o pipefail
 
 echo "Checking we report no errors on these test cases"
 flake8 --select BLK test_cases/*.py
+# Adding --black-config '' meaning ignore any pyproject.toml should have no effect:
+flake8 --select BLK test_cases/*.py --black-config ''
 flake8 --select BLK --max-line-length 50 test_cases/*.py
 flake8 --select BLK --max-line-length 90 test_cases/*.py
 flake8 --select BLK with_pyproject_toml/*.py
 flake8 --select BLK with_pyproject_toml/*.py --black-config with_pyproject_toml/pyproject.toml
 flake8 --select BLK without_pyproject_toml/*.py --config=flake8_config/flake8
 flake8 --select BLK --max-line-length 88 with_pyproject_toml/
+flake8 --select BLK without_pyproject_toml/*.py --black-config with_pyproject_toml/pyproject.toml
+# Adding --black-config '' should have no effect:
+#flake8 --select BLK --max-line-length 88 with_pyproject_toml/ --black-config ''
 flake8 --select BLK non_conflicting_configurations/*.py
 flake8 --select BLK conflicting_configurations/*.py
+# Here using --black-config '' meaning ignore any (bad) pyproject.toml files:
+flake8 --select BLK with_bad_toml/hello_world.py --black-config ''
 
 echo "Checking we report expected black changes"
 diff test_changes/hello_world.txt <(flake8 --select BLK test_changes/hello_world.py)
 diff test_changes/hello_world_EOF.txt <(flake8 --select BLK test_changes/hello_world_EOF.py)
+diff test_changes/hello_world_EOF.txt <(flake8 --select BLK test_changes/hello_world_EOF.py --black-config '')
+diff with_bad_toml/hello_world.txt <(flake8 --select BLK with_bad_toml/hello_world.py)
+diff with_pyproject_toml/ignoring_toml.txt <(flake8 with_pyproject_toml/ --select BLK --black-config '')
 
 echo "Tests passed."

--- a/tests/with_bad_toml/hello_world.py
+++ b/tests/with_bad_toml/hello_world.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Print 'Hello world' to the terminal.
+
+This is a simple test script using a hashbang line
+and a PEP263 encoding line.
+"""
+
+print("Hello world")

--- a/tests/with_bad_toml/hello_world.txt
+++ b/tests/with_bad_toml/hello_world.txt
@@ -1,0 +1,1 @@
+with_bad_toml/hello_world.py:0:1: BLK997 Invalid TOML file: with_bad_toml/pyproject.toml

--- a/tests/with_bad_toml/pyproject.toml
+++ b/tests/with_bad_toml/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+skip-string-normalization = true
+# This line is (a) in the wrong file, and (b) invalid syntax
+black-config=

--- a/tests/with_pyproject_toml/ignoring_toml.txt
+++ b/tests/with_pyproject_toml/ignoring_toml.txt
@@ -1,0 +1,1 @@
+with_pyproject_toml/ordinary_quotes.py:10:7: BLK100 Black would make changes.


### PR DESCRIPTION
A reworking of PR #15.

Builds on #11, makes the caching of parsed ``pyproject.toml`` files more explicit (run ``flake8 -v ... | grep black`` to see this in the logs).

Adds new ``BLK997`` if a ``pyproject.toml`` file is invalid, allows using ``flake8 --black-config '' ...`` (or any other bash syntax to pass an empty string) to mean ignore any ``pyproject.toml`` files.

What do you think @098799 ?