### PR TITLE
Making flake8-black a pre-commit.com plugins

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+-   id: flake8-black
+    name: flake8-black
+    description: flake8 plugin for validating Python code style with the command line code formatting tool black
+    entry: flake8_black.py
+    language: python
+    always_run: true
+    pass_filenames: false
+    minimum_pre_commit_version: 0.1.1

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,4 +5,4 @@
     language: python
     always_run: true
     pass_filenames: false
-    minimum_pre_commit_version: 0.1.1
+    minimum_pre_commit_version: 0.14.0


### PR DESCRIPTION
I would like to use flake8-black as a precommit plugin (https://pre-commit.com/hooks.html). I have tried to set it up, but think I am making a mistake:

```
pre-commit run -a
[INFO] Initializing environment for https://github.com/avivajpeyi/flake8-black.
[INFO] Installing environment for https://github.com/avivajpeyi/flake8-black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
flake8-black.............................................................Failed
hookid: flake8-black

Executable `flake8_black.py` not found

```
Would the flak8-black team have any suggestions?