### PR TITLE
pipenv version clash workaround

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,6 +150,12 @@ Version History
 ======= ============ ===========================================================
 Version Release date   Changes
 ------- ------------ -----------------------------------------------------------
+v0.2.0  2020-05-20   - Minimum requirement on black 19.3b0 or later is now
+                       implicit. This is a workaround for `pipenv issue 3928
+                       <https://github.com/pypa/pipenv/issues/3928>`_. Upgrade
+                       black if running flake8 gives an error like this:
+                       ``Flake8 failed to load plugin "BLK" due to __call__()
+                       got an unexpected keyword argument 'target_versions'.``
 v0.1.2  2020-05-18   - Removed test broken by flake8 v3.8 change to resolve
                        configuration files relative to current directory.
 v0.1.1  2019-08-26   - Option to use a (global) black configuration file,

--- a/flake8_black.py
+++ b/flake8_black.py
@@ -14,7 +14,7 @@ from flake8 import utils as stdin_utils
 from flake8 import LOG
 
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"
 
 black_prefix = "BLK"
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,6 @@ setup(
     ],
     keywords="PEP8",
     py_modules=["flake8_black"],
-    install_requires=["flake8 >= 3.0.0", "black >= 19.3b0"],
+    install_requires=["flake8 >= 3.0.0", "black"],
     entry_points={"flake8.extension": ["BLK = flake8_black:BlackStyleChecker"]},
 )


### PR DESCRIPTION
Should resolve issues #18 / #21 with the least bad workaround. I consider it unlikely that many people using black and flake8-black would be using anything older than black 19.3b0, which
is now over a year old.

@bbenne10 could you look at this please? e.g. Did you have strong reason for suggesting bumping the version of v0.2?