### PR TITLE
Let black deal with line length

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,12 +123,11 @@ We recommend using the following settings in your ``flake8`` configuration,
 for example in your ``.flake8``, ``setup.cfg``, or ``tox.ini`` file::
 
     [flake8]
-    # Recommend matching the black line length (default 88),
-    # rather than using the flake8 default of 79:
-    max-line-length = 88
     extend-ignore =
         # See https://github.com/PyCQA/pycodestyle/issues/373
         E203,
+        # Black already takes care of long lines
+        E501,
 
 Note currently ``pycodestyle`` gives false positives on the spaces ``black``
 uses for slices, which ``flake8`` reports as ``E203: whitespace before ':'``.


### PR DESCRIPTION
Hello,
I just installed flake8 3.9.2, black 21.6b0, flake8-black 0.2.1 and Django 3.2.4 (latest versions).
Then I run black and I configured flake8 using the suggested configuration, but it doesn't spark with joy:

```shell
$ flake8
./test_project/settings.py:89:89: E501 line too long (91 > 88 characters)
```

Seems like sometimes black does not really respect its own line length limit, here's line 89:

```python
AUTH_PASSWORD_VALIDATORS = [
    {
        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
    },
    # ...
]
```

My solution was to ask politely flake8 to mind its business and leave line lengths to black.
Here's a PR for it. Feel free to improve/change/correct/...