### PR TITLE
Use tox to run the tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,10 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install package
+    - name: Install tox
       run: |
-        python setup.py install
-        flake8 --version
+        pip install --upgrade pip
+        pip install tox
     - name: Run tests
       run: |
-        cd tests/
-        bash ./run_tests.sh
+        tox

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,13 @@ build
 #Ignore the distribution directory
 dist
 
+# Ignore the Tox directory
+.tox/
+
 #Ignore another Python specific build folder:
 flake8_black.egg-info/
- 
+__pycache__/
+
 #Ignore backup files from some Unix editors,
 *~
 *.swp

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,26 @@
+[testenv:flake8]
+skip_install = true
+deps =
+    flake8
+    flake8-docstrings
+commands =
+    flake8 .
+
+[testenv:restructuredtext_lint]
+skip_install = true
+deps =
+    restructuredtext-lint
+commands =
+    restructuredtext-lint *.rst
+
+[testenv:black]
+skip_install = true
+deps =
+    black
+commands =
+    black --check --extend-exclude=tests .
+
+[testenv:test]
+changedir = tests
+commands =
+    ./run_tests.sh


### PR DESCRIPTION
This adds Tox as a test environment runner. A major benefit of Tox is that it runs each test environment in an isolated, fresh virtualenv.

Note, this means that the lack of `toml` in `setup.py` actually causes tests to fail with Tox, since in the isolated virtualenv, no extra packages are installed (isolating your tests from the existing packages on the host system).

This also adds GitHub actions to run all tests via Tox for every PR and upon every merge to `master`.

Fixes #34.