### PR TITLE
Update black.find_project_root signature for black >= 22.1.0

### DIFF
--- a/flake8_black.py
+++ b/flake8_black.py
@@ -100,6 +100,10 @@ class BlackStyleChecker:
         project_root = black.find_project_root(
             ("." if self.filename in self.STDIN_NAMES else self.filename,)
         )
+        if isinstance(project_root, tuple):
+            # black stable 22.1.0 update find_project_root return value
+            # from Path to Tuple[Path, str]
+            project_root = project_root[0]
         path = project_root / "pyproject.toml"
 
         if path in black_config:


### PR DESCRIPTION
New `black` 22.1.0 breaks `flake8-black` with 

```
BLK999 Unexpected exception: unsupported operand type(s) for /: 'tuple' and 'str'
```
Because it update `find_project_root` return values: from `Path` to `Tuple[Path, str]` (https://github.com/psf/black/commit/521d1b8129c2d83b4ab49270fe7473802259c2a2)