### PR TITLE
Add compatibility with black 22

### DIFF
--- a/flake8_black.py
+++ b/flake8_black.py
@@ -99,7 +99,7 @@ class BlackStyleChecker:
         # Unless using override, we look for pyproject.toml
         project_root = black.find_project_root(
             ("." if self.filename in self.STDIN_NAMES else self.filename,)
-        )
+        )[0]
         path = project_root / "pyproject.toml"
 
         if path in black_config:


### PR DESCRIPTION
Utility function returns a tuple:
https://github.com/psf/black/pull/2526

https://github.com/psf/black/blob/521d1b8129c2d83b4ab49270fe7473802259c2a2/src/black/files.py#L43


Fixes #44 