### PR TITLE
Use `tomli.loads` instead of file load

### DIFF
--- a/flake8_black.py
+++ b/flake8_black.py
@@ -58,7 +58,7 @@ def load_black_mode(toml_filename=None):
     LOG.info("flake8-black: loading black settings from %s", toml_filename)
     try:
         with toml_filename.open(encoding="utf8") as toml_file:
-            pyproject_toml = tomli.load(toml_file)
+            pyproject_toml = tomli.loads(toml_file.read())
     except tomli.TOMLDecodeError:
         LOG.info("flake8-black: invalid TOML file %s", toml_filename)
         raise BadBlackConfig(path.relpath(toml_filename))


### PR DESCRIPTION
Fixes https://github.com/peterjc/flake8-black/issues/50
But might be a better way, I have limited `.toml` files on which to test. 