### PR TITLE
Recursively include tests/ in distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.rst
 include LICENSE.rst
 include requirements.txt
+graft tests


### PR DESCRIPTION
The 0.3.2 release on PyPI does not have the commas and black_preview files added since the 0.2.4 release. Perhaps this is needed?