### PR TITLE
Use tomllib on Python 3.11

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,6 +175,9 @@ Version History
 ======= ============ ===========================================================
 Version Release date Changes
 ------- ------------ -----------------------------------------------------------
+v0.3.6  *Pending*    - Use standard library ``tomllib`` on Python 3.11 onwards,
+                       contribution from
+                       `Ganden Schaffner <https://github.com/gschaffner>`_.
 v0.3.5  2022-11-21   - Fix regression clashing with ``flake8-rst-docstrings``.
 v0.3.4  2022-11-17   - Replaces ``setup.py`` with ``pyproject.toml`` for build.
 v0.3.3  2022-05-16   - Cope with line-length as string in pyproject.toml config.

--- a/flake8_black.py
+++ b/flake8_black.py
@@ -4,11 +4,16 @@ This is a plugin for the tool flake8 tool for checking Python
 source code using the tool black.
 """
 
+import sys
 from os import path
 from pathlib import Path
 
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
 import black
-import tomli
 
 from flake8 import utils as stdin_utils
 from flake8 import LOG
@@ -58,7 +63,7 @@ def load_black_mode(toml_filename=None):
     LOG.info("flake8-black: loading black settings from %s", toml_filename)
     try:
         with toml_filename.open(mode="rb") as toml_file:
-            pyproject_toml = tomli.load(toml_file)
+            pyproject_toml = tomllib.load(toml_file)
     except ValueError:
         LOG.info("flake8-black: invalid TOML file %s", toml_filename)
         raise BadBlackConfig(path.relpath(toml_filename))

--- a/flake8_black.py
+++ b/flake8_black.py
@@ -19,7 +19,7 @@ from flake8 import utils as stdin_utils
 from flake8 import LOG
 
 
-__version__ = "0.3.5"
+__version__ = "0.3.6"
 
 black_prefix = "BLK"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = '>=3.7'
 dependencies = [
   'flake8>=3',
   'black>=22.1.0',
-  'tomli',
+  'tomli ; python_version < "3.11"',
 ]
 dynamic = ['version']
 [project.entry-points]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ flake8 >= 3.0.0
 
 # We need black, which in turn needs Python 3.6+
 black
-tomli
+tomli ; python_version < "3.11"


### PR DESCRIPTION
hi! tomli was incorporated into the >= 3.11 stdlib as tomllib